### PR TITLE
Remove outdated sources and improve formatting in ABAP development section

### DIFF
--- a/Workshops/Week1/2-Setup-and-Configuration.md
+++ b/Workshops/Week1/2-Setup-and-Configuration.md
@@ -353,8 +353,6 @@ GitHub Copilot's Agent Mode in Eclipse **does not support the `semanticfs` URI s
 - Workspace-level operations that depend on file system access may be limited
 - You may encounter errors related to unsupported URI schemes when using agent features
 
-> **Source:** [Eclipse Marketplace - GitHub Copilot User Reviews](https://marketplace.eclipse.org/content/github-copilot)
-
 #### 2. ABAP Language Support Quality
 
 GitHub Copilot's AI models are trained primarily on publicly available code repositories. Since ABAP is a **proprietary SAP language** with limited open-source code available:
@@ -371,8 +369,6 @@ Users have reported dependency conflicts during GitHub Copilot installation in E
 - Conflicts with **Mylyn WikiText UI** and **LSP4e** components may occur
 - "Cannot satisfy dependency" errors may prevent installation
 - **Solution:** Ensure your Eclipse installation is fully up-to-date and consider removing conflicting plugins if necessary
-
-> **Source:** [Eclipse Marketplace - GitHub Copilot Reviews](https://marketplace.eclipse.org/content/github-copilot)
 
 #### 4. Network and Certificate Issues
 
@@ -392,17 +388,12 @@ ABAP development requires connection to an SAP backend system. GitHub Copilot:
 
 #### Best Practices for ABAP Developers Using Copilot
 
-1. **Use Copilot for boilerplate code** — Standard ABAP syntax, loops, SELECT statements, and common patterns
-2. **Provide detailed comments** — Help Copilot understand your intent with descriptive ABAP comments (`" comment`)
-3. **Verify all suggestions** — Always review generated ABAP code against SAP documentation and your system's data dictionary
+1. **Use Copilot for boilerplate code:** Standard ABAP syntax, loops, SELECT statements, and common patterns
+2. **Provide detailed comments:** Help Copilot understand your intent with descriptive ABAP comments (`" comment`)
+3. **Verify all suggestions:** Always review generated ABAP code against SAP documentation and your system's data dictionary
 4. **Combine with SAP tools** — Use Copilot alongside SAP's built-in code templates, patterns, and ABAP documentation
 5. **Leverage for non-ABAP files** — Copilot works well for related files like JSON, XML, JavaScript (UI5/Fiori), and documentation
 
-#### Official References
-
-- [SAP Development Tools](https://tools.hana.ondemand.com/#abap) — Official ADT download and documentation
-- [GitHub Copilot in Eclipse](https://docs.github.com/en/copilot/managing-copilot/configure-personal-settings/installing-the-github-copilot-extension-in-your-environment) — Official installation guide
-- [Eclipse Marketplace - GitHub Copilot](https://marketplace.eclipse.org/content/github-copilot) — Extension page with user reviews and known issues
 
 ---
 


### PR DESCRIPTION
Update the ABAP development documentation by removing outdated sources and enhancing formatting for better readability. This change aims to provide clearer guidance for users leveraging GitHub Copilot in ABAP development.