### PR TITLE
Add curriculum styling and research prompts for GitHub Copilot workshops

### DIFF
--- a/.github/instructions/Currriculum-Styling.instructions.md
+++ b/.github/instructions/Currriculum-Styling.instructions.md
@@ -1,0 +1,15 @@
+---
+description: Curriculum styling instructions for the GitHub Copilot workshops and Issue templates.
+applyTo: "**/*.md,**/.github/ISSUE_TEMPLATE/*.yaml"
+---
+
+- Always use the same formatting for headings, lists, and links across all markdown files to maintain a consistent style.
+- Use British English spelling (e.g., "familiarise" instead of "familiarize") throughout the curriculum.
+- When listing prerequisites, use bullet points and ensure that each item is concise and clear.
+- In Code blocks always comment on the purpose of the code and any important details that learners should be aware of.
+- Do not use emdashes (—) in markdown files, instead use full stops (.) or commas (,) to separate clauses in sentences.
+- Ensure all pages have a "Next Steps" section at the end that guides learners on what to do after completing the current page, such as linking to the next page in the curriculum or additional resources. Except for "FAQ" documents.
+- When content is updated, ensure that the main README.md file on the repo root is also updated to reflect any changes in the curriculum structure or content.
+- When the curriculum is updated, update the `**Last Updated:** DD/MM/YYYY` line near the top of README.md to reflect today's date in DD/MM/YYYY format.
+- For issue templates, ensure that the template is clear and concise, with specific sections for the user to fill out (e.g., "Description of the issue", "Steps to reproduce", "Expected behavior", "Actual behavior", etc.).
+- When content is updated also ensure that the issue templates are reviewed and updated if necessary to reflect any changes in the curriculum.

--- a/.github/prompts/Research.prompt.md
+++ b/.github/prompts/Research.prompt.md
@@ -1,0 +1,8 @@
+---
+name: Research
+description: Research and verify the latest features and changes to GitHub Copilot, ensuring that all curriculum content is up-to-date and accurate based on the most recent online sources.
+---
+
+- With the fast moving pace of features and changes to GitHub Copilot, can you please verify and look at the correctness of the content in the curriculum based on the latest online sources, and update any information that is outdated or incorrect? Please ensure that all information is accurate and reflects the current state of GitHub Copilot as of today's date from online sources. This includes any new features, changes to existing features, or updates to the user interface that may have occurred since the last update of the curriculum. Please provide references to the sources you used for verification and updating the content.
+
+- You can still reference deprecated features or older versions of GitHub Copilot in the curriculum, but please ensure that it is clearly indicated as such and that the most up-to-date information is also included for learners to understand the current state of GitHub Copilot.


### PR DESCRIPTION
Introduce consistent styling guidelines for markdown files and issue templates in the GitHub Copilot curriculum. Include prompts for verifying and updating content based on the latest features and changes to GitHub Copilot.