### PR TITLE
Add weekly-curriculum Copilot skill

### DIFF
--- a/.github/instructions/Currriculum-Styling.instructions.md
+++ b/.github/instructions/Currriculum-Styling.instructions.md
@@ -13,3 +13,4 @@ applyTo: "**/*.md,**/.github/ISSUE_TEMPLATE/*.yaml"
 - When the curriculum is updated, update the `**Last Updated:** DD/MM/YYYY` line near the top of README.md to reflect today's date in DD/MM/YYYY format.
 - For issue templates, ensure that the template is clear and concise, with specific sections for the user to fill out (e.g., "Description of the issue", "Steps to reproduce", "Expected behavior", "Actual behavior", etc.).
 - When content is updated also ensure that the issue templates are reviewed and updated if necessary to reflect any changes in the curriculum.
+- When adding a brand new week of content, prefer the `weekly-curriculum` skill in `.github/skills/weekly-curriculum/SKILL.md`. It enforces the folder layout, placeholder fill-in, styling rules, and root README updates automatically.

--- a/.github/instructions/Currriculum-Styling.instructions.md
+++ b/.github/instructions/Currriculum-Styling.instructions.md
@@ -11,6 +11,6 @@ applyTo: "**/*.md,**/.github/ISSUE_TEMPLATE/*.yaml"
 - Ensure all pages have a "Next Steps" section at the end that guides learners on what to do after completing the current page, such as linking to the next page in the curriculum or additional resources. Except for "FAQ" documents.
 - When content is updated, ensure that the main README.md file on the repo root is also updated to reflect any changes in the curriculum structure or content.
 - When the curriculum is updated, update the `**Last Updated:** DD/MM/YYYY` line near the top of README.md to reflect today's date in DD/MM/YYYY format.
-- For issue templates, ensure that the template is clear and concise, with specific sections for the user to fill out (e.g., "Description of the issue", "Steps to reproduce", "Expected behavior", "Actual behavior", etc.).
+- For issue templates, ensure that the template is clear and concise, with specific sections for the user to fill out (e.g., "Description of the issue", "Steps to reproduce", "Expected behaviour", "Actual behaviour", etc.).
 - When content is updated also ensure that the issue templates are reviewed and updated if necessary to reflect any changes in the curriculum.
 - When adding a brand new week of content, prefer the `weekly-curriculum` skill in `.github/skills/weekly-curriculum/SKILL.md`. It enforces the folder layout, placeholder fill-in, styling rules, and root README updates automatically.

--- a/.github/skills/weekly-curriculum/SKILL.md
+++ b/.github/skills/weekly-curriculum/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: weekly-curriculum
+description: Scaffold a new weekly workshop for the GitHub Copilot Bootcamp curriculum. Use when the user asks to add a new week, create a new workshop, generate Week N content, scaffold weekly curriculum, draft a new bootcamp module, or add a new topic such as "MCPs with GitHub Copilot" to the training programme. Generates the Workshops/WeekN folder, the four standard markdown pages (two sessions, one lab, one prompts reference), the matching lab issue template, and updates the root README.md and Last Updated date.
+license: MIT
+---
+
+# Weekly Curriculum Scaffolder
+
+Use this skill to add a brand new week of content to the GitHub Copilot Bootcamp curriculum. It enforces the existing folder layout, file naming, placeholder fill-in, styling rules, and root README updates so a new week is consistent with Weeks 1 to 4.
+
+## When to use this skill
+
+- The user asks to add, create, scaffold, or draft a new week of workshop content.
+- The user names a topic for a future week (for example "MCPs with GitHub Copilot", "Security with Copilot", "Testing with Copilot").
+- The user wants to extend the curriculum and asks how to start, or asks you to "use the templates".
+
+## When NOT to use this skill
+
+- Editing or fixing content inside an existing week. Edit those files directly and follow `.github/instructions/Currriculum-Styling.instructions.md`.
+- Updating only the FAQ, metrics, or the root README without adding a new week.
+- Authoring a new GitHub Copilot Skill or prompt file. Those are unrelated to weekly workshop content.
+
+## Inputs to gather from the user
+
+Before generating any files, confirm the following with the user. Ask them as one batched question if values are missing, and use sensible defaults where shown.
+
+| Input | Required | Example | Notes |
+|---|---|---|---|
+| Week number | Yes | `5` | Must be the next free integer after the highest existing `Workshops/WeekN/` folder. |
+| Week title | Yes | `MCPs with GitHub Copilot` | Short, sentence case, no trailing punctuation. |
+| Week objective | Yes | `Understand the Model Context Protocol and integrate MCP servers with GitHub Copilot.` | One sentence. |
+| Week total duration | No | `2-3 hours` | Default `2-3 hours`. |
+| Session 1 title | Yes | `Introduction to the Model Context Protocol` | |
+| Session 2 title | Yes | `Using and Building MCP Servers with Copilot` | |
+| Lab style | Yes | `skills` or `self-contained` | `skills` links to an external `github.com/skills/...` repo. `self-contained` embeds full exercises inline. |
+| External GitHub Skills repo | Conditional | `skills/integrate-mcp-with-copilot` | Required when lab style is `skills`. |
+| Lab title | Yes | `Hands-On with MCP Servers` | |
+| Lab duration | No | `60-90 minutes` | Default `60-90 minutes`. |
+| Four lab activities | Yes | Short labels for the issue template checkboxes | Used as `{{ACTIVITY_1}}` to `{{ACTIVITY_4}}`. |
+| Prompt categories (5 to 8) | Yes | `MCP discovery`, `Server configuration`, `Tool invocation`, ... | Used in the prompts reference. |
+
+If any required input is missing or ambiguous, ask the user before generating files.
+
+## Step-by-step workflow
+
+Follow these steps in order. Read each referenced file from the repository before generating output so placeholders match the latest template versions.
+
+### 1. Verify the target week is free
+
+1. List `Workshops/` and confirm `Workshops/Week{{WEEK_NUMBER}}/` does not already exist.
+2. Confirm `.github/ISSUE_TEMPLATE/week{{WEEK_NUMBER}}-lab.yml` does not already exist.
+3. If either exists, stop and ask the user how to proceed.
+
+### 2. Read the canonical templates
+
+Read these files from the repo before authoring anything. They are the source of truth for structure and placeholders, do not invent your own layout:
+
+- `templates/SESSION-TEMPLATE.md`
+- `templates/LAB-SKILLS-TEMPLATE.md` (if `lab style` is `skills`)
+- `templates/LAB-SELF-CONTAINED-TEMPLATE.md` (if `lab style` is `self-contained`)
+- `templates/PROMPTS-TEMPLATE.md`
+- `templates/ISSUE-TEMPLATE.yml`
+- `templates/README-SNIPPET.md`
+- `templates/README.md` for the full placeholder reference table
+
+### 3. Create the Workshops/WeekN folder and four pages
+
+Create the folder `Workshops/Week{{WEEK_NUMBER}}/` and write these four files. File naming is mandatory:
+
+```text
+Workshops/Week{{WEEK_NUMBER}}/
+├── 1-{{SESSION_1_FILENAME}}.md          # from SESSION-TEMPLATE.md
+├── 2-{{SESSION_2_FILENAME}}.md          # from SESSION-TEMPLATE.md
+├── 3-Week{{WEEK_NUMBER}}-Lab.md         # from chosen LAB template
+└── 4-Week{{WEEK_NUMBER}}-Prompts.md     # from PROMPTS-TEMPLATE.md
+```
+
+Rules for the session filenames:
+
+- Convert the session title to title case with hyphens, drop punctuation. Example: `Introduction to the Model Context Protocol` becomes `Introduction-to-the-Model-Context-Protocol`.
+- Final filename is `1-Introduction-to-the-Model-Context-Protocol.md`.
+
+For each generated file:
+
+- Replace every `{{PLACEHOLDER}}` with a real value. Do not leave any `{{` or `}}` markers in committed output.
+- Ensure each session page has three main sections, a Best Practices table (4 to 6 rows), four Key Takeaways, three Discussion Questions, and a Next Steps section.
+- Ensure each page ends with a `## Next Steps` section that links to the next file in the sequence. The last page (prompts) links forward to the next week if known, otherwise to the weekly reflection issue template.
+- Cross-link files using relative paths within the week folder, for example `2-...md`, `3-Week5-Lab.md`, `4-Week5-Prompts.md`.
+
+### 4. Create the lab issue template
+
+1. Copy `.github/ISSUE_TEMPLATE/week1-lab.yml` as the structural baseline (it is the most complete real example).
+2. Save it as `.github/ISSUE_TEMPLATE/week{{WEEK_NUMBER}}-lab.yml`.
+3. Replace the week number, lab title, session filenames, and the four activity labels.
+4. Keep the IDE dropdown, Copilot modes checkboxes, time impact dropdown, and confidence dropdown unchanged unless the user explicitly asks otherwise.
+
+### 5. Update the root README.md
+
+1. Read `templates/README-SNIPPET.md`.
+2. Fill all placeholders. Provide four bullets for each session, four for the lab, and four for the prompts reference.
+3. Insert the filled snippet into `README.md` under the `## Curriculum` heading, placed after the previous week and before any `## Additional Resources` heading.
+4. Add the Table of Contents entries from the snippet's HTML comment block to the existing TOC at the top of `README.md`, immediately after the previous week's entries. Compute markdown anchor slugs by lowercasing the heading and replacing spaces and punctuation with single hyphens.
+5. Update the `**Last Updated:** DD/MM/YYYY` line near the top of `README.md` to today's date in DD/MM/YYYY format.
+
+### 6. Validate against the styling checklist
+
+Run through every item in [references/CHECKLIST.md](references/CHECKLIST.md) before reporting done. If any item fails, fix it before finishing.
+
+### 7. Report back to the user
+
+Summarise:
+
+- The folder and files created.
+- Lines changed in `README.md`.
+- Any placeholders that still need a human decision (for example, a real GitHub Skills exercise URL when one does not yet exist).
+- Suggested git commit message, for example `Add Week 5: MCPs with GitHub Copilot`.
+
+Do not push or open a pull request unless the user explicitly asks.
+
+## Styling rules that must be enforced
+
+These are pulled from `.github/instructions/Currriculum-Styling.instructions.md` and `.github/instructions/markdown.instructions.md`. They apply to every file you generate.
+
+- British English spelling and grammar throughout (for example "customise", "behaviour", "organisation").
+- No em dashes (—). Use a full stop or comma instead.
+- No emojis.
+- Every page ends with a `## Next Steps` section, except FAQ documents (this skill does not edit FAQ).
+- Code blocks include a comment explaining purpose and any important details.
+- Tables are used for comparisons, feature matrices, and best practices.
+- Headings follow the hierarchy: H1 for page title, H2 for major sections, H3 for subsections.
+- Verify any external links and references against authoritative sources before including them.
+
+## Examples
+
+### Example invocation
+
+> User: "Add a new week to the bootcamp covering MCPs and how to use them with GitHub Copilot."
+
+Expected behaviour:
+
+1. Confirm Week 5 is free.
+2. Ask the user (one batched question) for: session 1 and 2 titles, lab style, four lab activities, five to eight prompt categories. Suggest sensible defaults for the topic.
+3. Generate `Workshops/Week5/1-...md`, `2-...md`, `3-Week5-Lab.md`, `4-Week5-Prompts.md`.
+4. Generate `.github/ISSUE_TEMPLATE/week5-lab.yml`.
+5. Update `README.md` curriculum section, TOC, and Last Updated date.
+6. Run the checklist.
+7. Report changes and suggest a commit message.
+
+### Example session filename derivation
+
+| Session title | Derived filename |
+|---|---|
+| `Introduction to the Model Context Protocol` | `1-Introduction-to-the-Model-Context-Protocol.md` |
+| `Using and Building MCP Servers with Copilot` | `2-Using-and-Building-MCP-Servers-with-Copilot.md` |
+
+## Edge cases
+
+- **Lab style is `skills` but no real GitHub Skills exercise exists.** Fall back to `self-contained` and warn the user. Do not invent a `github.com/skills/<repo>` URL.
+- **The user provides only a topic with no session titles.** Propose two session titles and confirm with the user before generating.
+- **`README.md` TOC anchors collide** because two weeks share session titles. Append the week number to the anchor, for example `#1-introduction-week-5`.
+- **The user wants more or fewer than two sessions.** The current convention is exactly two sessions, one lab, one prompts page. If the user wants a different shape, confirm explicitly and update file numbers accordingly (`{{LAB_FILE_NUMBER}}` and `{{PROMPTS_FILE_NUMBER}}`).
+- **The user already started the new week manually.** Ask whether to overwrite, merge, or abort.
+
+## Files in this skill
+
+- [SKILL.md](SKILL.md) - this file.
+- [references/CHECKLIST.md](references/CHECKLIST.md) - validation checklist run before reporting done.
+
+## Next Steps
+
+After scaffolding a new week, recommend the user:
+
+1. Review the generated files in the new branch and tweak content for accuracy.
+2. Run the `Research.prompt.md` prompt in `.github/prompts/` to verify all external references are current.
+3. Open a pull request for review when satisfied.

--- a/.github/skills/weekly-curriculum/SKILL.md
+++ b/.github/skills/weekly-curriculum/SKILL.md
@@ -157,7 +157,7 @@ Expected behaviour:
 
 - **Lab style is `skills` but no real GitHub Skills exercise exists.** Fall back to `self-contained` and warn the user. Do not invent a `github.com/skills/<repo>` URL.
 - **The user provides only a topic with no session titles.** Propose two session titles and confirm with the user before generating.
-- **`README.md` TOC anchors collide** because two weeks share session titles. Append the week number to the anchor, for example `#1-introduction-week-5`.
+- **`README.md` TOC anchors collide** because two weeks share session titles. Make the headings unique, for example by including `Week {{WEEK_NUMBER}}` in the heading text, so the generated GitHub anchor is unique. If duplicate headings must remain, use GitHub's deduplicated anchor format with `-1`, `-2`, and so on.
 - **The user wants more or fewer than two sessions.** The current convention is exactly two sessions, one lab, one prompts page. If the user wants a different shape, confirm explicitly and update file numbers accordingly (`{{LAB_FILE_NUMBER}}` and `{{PROMPTS_FILE_NUMBER}}`).
 - **The user already started the new week manually.** Ask whether to overwrite, merge, or abort.
 

--- a/.github/skills/weekly-curriculum/references/CHECKLIST.md
+++ b/.github/skills/weekly-curriculum/references/CHECKLIST.md
@@ -5,7 +5,7 @@ Run through every item before reporting the new week as done. Fix any failure be
 ## Folder and files
 
 - [ ] `Workshops/Week{{WEEK_NUMBER}}/` exists and contains exactly four markdown files.
-- [ ] File names follow the pattern `1-Title.md`, `2-Title.md`, `3-Week{{N}}-Lab.md`, `4-Week{{N}}-Prompts.md`.
+- [ ] File names follow the pattern `1-Title.md`, `2-Title.md`, `3-Week{{WEEK_NUMBER}}-Lab.md`, `4-Week{{WEEK_NUMBER}}-Prompts.md`.
 - [ ] No `{{PLACEHOLDER}}` markers remain in any generated file.
 - [ ] All relative links between the four files resolve.
 
@@ -20,7 +20,7 @@ Run through every item before reporting the new week as done. Fix any failure be
 
 - [ ] A new `### Week {{WEEK_NUMBER}}: {{WEEK_TITLE}}` section has been added under `## Curriculum`, in numerical order.
 - [ ] Four bullets per session, lab, and prompts list (no empty bullets, no placeholders).
-- [ ] Two feedback links present: `week{{N}}-lab.yml` and `weekly-reflection.yml`.
+- [ ] Two feedback links present: `week{{WEEK_NUMBER}}-lab.yml` and `weekly-reflection.yml`.
 - [ ] Table of Contents at the top of `README.md` has matching entries with valid anchor slugs.
 - [ ] `**Last Updated:** DD/MM/YYYY` line reflects today's date in DD/MM/YYYY format.
 
@@ -49,4 +49,4 @@ Run through every item before reporting the new week as done. Fix any failure be
 
 - [ ] Summary of created files and changed files.
 - [ ] List of any human decisions still required.
-- [ ] Suggested git commit message of the form `Add Week {{N}}: {{WEEK_TITLE}}`.
+- [ ] Suggested git commit message of the form `Add Week {{WEEK_NUMBER}}: {{WEEK_TITLE}}`.

--- a/.github/skills/weekly-curriculum/references/CHECKLIST.md
+++ b/.github/skills/weekly-curriculum/references/CHECKLIST.md
@@ -1,0 +1,52 @@
+# Weekly Curriculum Scaffolding Checklist
+
+Run through every item before reporting the new week as done. Fix any failure before finishing.
+
+## Folder and files
+
+- [ ] `Workshops/Week{{WEEK_NUMBER}}/` exists and contains exactly four markdown files.
+- [ ] File names follow the pattern `1-Title.md`, `2-Title.md`, `3-Week{{N}}-Lab.md`, `4-Week{{N}}-Prompts.md`.
+- [ ] No `{{PLACEHOLDER}}` markers remain in any generated file.
+- [ ] All relative links between the four files resolve.
+
+## Issue template
+
+- [ ] `.github/ISSUE_TEMPLATE/week{{WEEK_NUMBER}}-lab.yml` exists.
+- [ ] Title prefix, labels, and week number all match `{{WEEK_NUMBER}}`.
+- [ ] The four activity checkboxes have been replaced with real activity labels.
+- [ ] References to session filenames inside the issue template match the real generated filenames.
+
+## Root README.md
+
+- [ ] A new `### Week {{WEEK_NUMBER}}: {{WEEK_TITLE}}` section has been added under `## Curriculum`, in numerical order.
+- [ ] Four bullets per session, lab, and prompts list (no empty bullets, no placeholders).
+- [ ] Two feedback links present: `week{{N}}-lab.yml` and `weekly-reflection.yml`.
+- [ ] Table of Contents at the top of `README.md` has matching entries with valid anchor slugs.
+- [ ] `**Last Updated:** DD/MM/YYYY` line reflects today's date in DD/MM/YYYY format.
+
+## Styling and language
+
+- [ ] British English spelling throughout. Common swaps: customize -> customise, behavior -> behaviour, organize -> organise, color -> colour.
+- [ ] No em dashes (—) anywhere in the new files. Use full stops or commas.
+- [ ] No emojis anywhere in the new files.
+- [ ] Every new page ends with a `## Next Steps` section.
+- [ ] Code blocks include comments explaining purpose and any important details.
+- [ ] Heading hierarchy is consistent: one H1 per page, H2 for major sections, H3 for subsections.
+
+## Cross-linking
+
+- [ ] Session 1 Next Steps links to Session 2.
+- [ ] Session 2 Next Steps links to the Lab.
+- [ ] Lab Next Steps links to the Prompts reference.
+- [ ] Prompts Next Steps links forward (to the next week if known, otherwise the weekly reflection issue template).
+
+## External references
+
+- [ ] Any external links to docs.github.com, code.visualstudio.com, or github.com/skills resolve and refer to real, current pages.
+- [ ] No invented or hallucinated URLs.
+
+## Final report
+
+- [ ] Summary of created files and changed files.
+- [ ] List of any human decisions still required.
+- [ ] Suggested git commit message of the form `Add Week {{N}}: {{WEEK_TITLE}}`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Thank you for helping improve this training curriculum! Here's how to contribute
 
 ## Adding a New Week
 
-The fastest way to add a new week is to use the **weekly-curriculum** Copilot skill in `.github/skills/weekly-curriculum/`. Ask GitHub Copilot something like "add a new week covering <topic>" and it will scaffold the `Workshops/WeekN/` folder, the lab issue template, and the root `README.md` updates from the canonical templates in `templates/`.
+The fastest way to add a new week is to use the **weekly-curriculum** Copilot skill in `.github/skills/weekly-curriculum/`. Ask GitHub Copilot something like `add a new week covering <topic>` and it will scaffold the `Workshops/WeekN/` folder, the lab issue template, and the root `README.md` updates from the canonical templates in `templates/`.
 
 If you prefer to scaffold by hand, copy the files in `templates/` and follow the placeholder reference in `templates/README.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,20 @@ Thank you for helping improve this training curriculum! Here's how to contribute
 3. Make your changes
 4. Submit a pull request with a clear description
 
+## Adding a New Week
+
+The fastest way to add a new week is to use the **weekly-curriculum** Copilot skill in `.github/skills/weekly-curriculum/`. Ask GitHub Copilot something like "add a new week covering <topic>" and it will scaffold the `Workshops/WeekN/` folder, the lab issue template, and the root `README.md` updates from the canonical templates in `templates/`.
+
+If you prefer to scaffold by hand, copy the files in `templates/` and follow the placeholder reference in `templates/README.md`.
+
 ## Content Structure
 
 | Folder | Purpose |
 |--------|---------|
 | `Workshops/WeekN/` | Weekly training content and labs |
 | `FAQ/` | Guides for facilitators and participants |
+| `templates/` | Canonical templates for new weekly content |
+| `.github/skills/` | Copilot skills that automate repository workflows |
 | `.github/ISSUE_TEMPLATE/` | Lab reflection templates |
 
 ## Questions?

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,7 +2,11 @@
 
 This folder contains reusable templates for creating new weekly curriculum material. Each template mirrors the file and folder structure used in `Workshops/Week1/` through `Workshops/Week4/`.
 
-## How to Use
+## Recommended: Use the Weekly Curriculum Skill
+
+The `.github/skills/weekly-curriculum/` skill automates the steps below. Ask GitHub Copilot to "add a new week" and it will read these templates, fill the placeholders, create the issue template, and update the root `README.md`. See [`.github/skills/weekly-curriculum/SKILL.md`](../.github/skills/weekly-curriculum/SKILL.md).
+
+## How to Use (manual)
 
 1. **Copy** the templates into a new folder, e.g. `Workshops/Week5/`.
 2. **Rename** each file following the numbering convention: `{N}-{Topic-Name}.md`.


### PR DESCRIPTION
Adds .github/skills/weekly-curriculum/ with SKILL.md and a validation CHECKLIST.md so Copilot can scaffold a new week of bootcamp content from the canonical templates in templates/. Updates CONTRIBUTING.md, templates/README.md, and the curriculum styling instructions to point contributors at the new skill.